### PR TITLE
Fix share checks and token metadata

### DIFF
--- a/contracts/StakingManager.sol
+++ b/contracts/StakingManager.sol
@@ -18,7 +18,7 @@ contract StakingManager is Ownable, StakingModifiers {
      */
     constructor(
         IERC4626 _stakingVault
-    ) ERC20("***", "***") Ownable(_msgSender()) {
+    ) ERC20("Staking Share", "STK") Ownable(_msgSender()) {
         if (address(_stakingVault) == address(0)) revert ZeroAddress();
 
         stakingVault = _stakingVault;

--- a/contracts/StakingModifiers.sol
+++ b/contracts/StakingModifiers.sol
@@ -14,7 +14,7 @@ abstract contract StakingModifiers is StakingState {
 
     /// @notice Reverts if the caller does not have enough shares
     modifier hasEnoughShares(uint256 shares) {
-        if (balanceOf(msg.sender) >= shares) revert InsufficientShares();
+        if (balanceOf(msg.sender) < shares) revert InsufficientShares();
         _;
     }
 }


### PR DESCRIPTION
## Summary
- update `hasEnoughShares` modifier logic
- give staking share token a name/symbol

## Testing
- `npx hardhat test`


------
https://chatgpt.com/codex/tasks/task_e_685e69c642948330808603346cfedec6